### PR TITLE
Implement serialize/2 with lexbor_erl backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 December, 2025
 
 - **BREAKING:** Replaced C-Node binding with [lexbor_erl](https://github.com/f34nk/lexbor_erl/tree/master) backend
-- Migrated `find/2`, `get_attribute/2,3`, `set_attribute/4`, `get_text/1,2`, `set_text/3`, `remove/2`, `append/3`, `prepend/3`, `insert_before/3`, `insert_after/3`, `replace/3`
-- Not yet implemented: `serialize/2`
+- Migrated `find/2`, `get_attribute/2,3`, `set_attribute/4`, `get_text/1,2`, `set_text/3`, `remove/2`, `append/3`, `prepend/3`, `insert_before/3`, `insert_after/3`, `replace/3`, `serialize/2`
 - Not supported: `position/2`, `wrap/3`, `slice/4`, `pretty_print/1`
 - Replaced Travis CI with GitHub Actions
 - Added multi-OS testing (Ubuntu, macOS)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [CHANGELOG](https://github.com/f34nk/modest_ex/blob/master/CHANGELOG.md).
   - [x] GitHub Actions CI (Ubuntu, macOS)
 - [ ] Features
   - [x] Find nodes using a CSS selector
-  - [ ] Serialize any string with valid or broken html
+  - [x] Serialize any string with valid or broken html
   - [x] Get attribute with optional CSS selector
   - [x] Set attribute with optional CSS selector
   - [x] Get text with optional CSS selector

--- a/lib/modest_ex/serialize.ex
+++ b/lib/modest_ex/serialize.ex
@@ -7,8 +7,15 @@ defmodule ModestEx.Serialize do
 
   def serialize([], _), do: []
 
-  def serialize(bin, scope) when is_bitstring(bin) when is_atom(scope) do
-    # ModestEx.Safe.Serialize.serialize(bin, scope)
-    ModestEx.LexborHelper.not_implemented("serialize/2")
+  def serialize(bin, scope) when is_bitstring(bin) and is_atom(scope) do
+    ModestEx.LexborHelper.ensure_started()
+
+    case :lexbor_erl.parse_serialize(bin) do
+      {:ok, full_html} ->
+        ModestEx.LexborHelper.apply_scope(full_html, scope)
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 end

--- a/test/modest_ex_serialize_test.exs
+++ b/test/modest_ex_serialize_test.exs
@@ -2,19 +2,16 @@ defmodule ModestExSerializeTest do
   use ExUnit.Case
   # doctest ModestEx
 
-  @tag :skip
   test "can serialize an empty string" do
     result = ModestEx.serialize("", :html)
     assert result == "<html><head></head><body></body></html>"
   end
 
-  @tag :skip
   test "use custom scope to control serialization" do
     result = ModestEx.serialize("<div>Hello<span>World", :body_children)
     assert result == "<div>Hello<span>World</span></div>"
   end
 
-  @tag :skip
   test "all test cases from file" do
     File.open("test/fixtures/serialize.csv", [:read], fn file ->
       IO.binstream(file, :line)


### PR DESCRIPTION
**This PR does**:
- Implement `serialize/2` using `lexbor_erl.parse_serialize/1` for HTML normalization
- Support all scope options: `:html`, `:body`, `:body_children`, `:head`
- Enable serialize tests (previously skipped)
- Update CHANGELOG and README to reflect 12/15 features now implemented

**This can be verified by doing**:
- Run `mix test test/modest_ex_serialize_test.exs` (3 tests pass)
- Test in IEx: `ModestEx.serialize("<div>Hello<span>World", :body_children)` returns `"<div>Hello<span>World</span></div>"`